### PR TITLE
Allow enabling JPS logging

### DIFF
--- a/jps-gradle-plugin/build.gradle.kts
+++ b/jps-gradle-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("com.gradle.plugin-publish") version "1.2.0"
 }
 
-version = "0.3.9"
+version = "0.3.10"
 group = "gradle.plugin.com.jetbrains.intellij"
 
 gradlePlugin {

--- a/jps-gradle-plugin/src/main/kotlin/jps/plugin/JpsCompile.kt
+++ b/jps-gradle-plugin/src/main/kotlin/jps/plugin/JpsCompile.kt
@@ -87,6 +87,10 @@ abstract class JpsCompile @Inject constructor(
     @Input
     val jvmArgs = objectFactory.listProperty<String>()
 
+    @Optional
+    @Input
+    val buildLogPath = objectFactory.property<String>()
+
     @Internal
     val outputPath = objectFactory.directoryProperty()
 
@@ -144,6 +148,7 @@ abstract class JpsCompile @Inject constructor(
                 "withProgress" to withProgress.get().toString(),
                 "jdkTable" to jdkTable.absolutePath,
                 "outputPath" to outputPath.get().asFile.absolutePath,
+                "buildLogPath" to buildLogPath.orNull,
             ).forEach { (name, value) ->
                 systemProperty(name.withPrefix(), value)
             }

--- a/jps-wrapper/build.gradle.kts
+++ b/jps-wrapper/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 val jpsVersion = "221.3598"
 
-project.version = "0.28"
+project.version = "0.29"
 
 dependencies {
     compileOnly("com.jetbrains.intellij.tools:jps-build-standalone:$jpsVersion") {

--- a/jps-wrapper/src/main/kotlin/jps/wrapper/Properties.kt
+++ b/jps-wrapper/src/main/kotlin/jps/wrapper/Properties.kt
@@ -28,6 +28,8 @@ object Properties {
     val forceRebuild = !incremental.toBoolean()
 
     var dataStorageRoot by NullableDelegate
+    
+    var buildLogPath by NullableDelegate
 
     val classpathOutputFilePath by NullableDelegate
 

--- a/jps-wrapper/src/main/kotlin/jps/wrapper/main.kt
+++ b/jps-wrapper/src/main/kotlin/jps/wrapper/main.kt
@@ -3,7 +3,7 @@ package jps.wrapper
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.util.io.URLUtil.*
-import org.jetbrains.jps.build.Standalone
+import org.jetbrains.jps.cmdline.LogSetup
 import org.jetbrains.jps.incremental.messages.BuildMessage
 import org.jetbrains.jps.incremental.messages.FileGeneratedEvent
 import org.jetbrains.jps.incremental.messages.ProgressMessage
@@ -24,6 +24,8 @@ import java.nio.file.Paths
 import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
+    setupLogging()
+
     val jpsModel = jpsModel()
     if (args.contains("buildOnlyClasspathFile")) {
         buildOnlyClasspathFile(jpsModel)
@@ -33,7 +35,6 @@ fun main(args: Array<String>) {
 }
 
 private fun jpsModel(): JpsModel {
-    System.setProperty("jps.use.default.file.logging", "false")
     val kotlinHome = Properties.kotlinHome
     if (kotlinHome != null) {
         System.setProperty("jps.kotlin.home", kotlinHome)
@@ -282,4 +283,18 @@ private fun getCurrentJdk(): String {
     }
 
     return javaHome
+}
+
+private fun setupLogging() {
+    Properties.buildLogPath.let { logPath ->
+        println("buildLogPath=${logPath}")
+        if (logPath == null) {
+            System.setProperty("jps.use.default.file.logging", "false")
+        }
+        else {
+            System.setProperty("jps.use.default.file.logging", "true")
+            System.setProperty("jps.log.dir", logPath)
+        }
+    }
+    LogSetup.initLoggers()
 }


### PR DESCRIPTION
Right now JPS logs are force-disabled. I am introducing a property `buildLogPath` which will enable logging and redirect it to a given dir. According to JPS logic, that dir also will accommodate log config (in file `build-log-jul.properties`)